### PR TITLE
build: enable semantic-release

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -17,7 +17,7 @@ workflows:
     jobs:
       - cypress/run:
           start: npm run dev:prod
-      # - release:
-      #     name: semantic-release 🚀
-      #     requires:
-      #       - cypress/run
+      - release:
+          name: semantic-release 🚀
+          requires:
+            - cypress/run


### PR DESCRIPTION
This PR enables semantic release for future `main` and `next` branch commits.