### PR TITLE
chore: fix reference from src to source in installation docs

### DIFF
--- a/docs/src/overview/installation.md
+++ b/docs/src/overview/installation.md
@@ -49,7 +49,7 @@ We highly recommend self-hosting the library if you are using it in a production
     <h1>There is no bundler or bundling involved!</h1>
     <ix-video
       controls
-      src="https://assets.imgix.video/videos/girl-reading-book-in-library.mp4"
+      source="https://assets.imgix.video/videos/girl-reading-book-in-library.mp4"
     >
   </body>
 </html>


### PR DESCRIPTION
Missed this in #6 . Will follow up with a vuepress docs deploy.