### PR TITLE
chore: update docs build script to build before deploy

### DIFF
--- a/package.json
+++ b/package.json
@@ -35,7 +35,7 @@
     "dev:prod": "vite --mode production --config ./dev/vite.config.ts",
     "docs:dev": "cd docs && npm run dev",
     "docs:build": "cd docs && npm run build",
-    "docs:deploy": "cd docs && npx gh-pages -d src/.vuepress/dist",
+    "docs:deploy": "cd docs && npm run build && npx gh-pages -d src/.vuepress/dist",
     "lint": "npm run lint:lit-analyzer && npm run lint:eslint",
     "lint:eslint": "eslint 'src/**/*.ts'",
     "lint:lit-analyzer": "lit-analyzer",


### PR DESCRIPTION
> merge after #8 
## Before this PR
Docs would not build before running `npm run docs:deploy`. Running this without running `npm run docs:buld` meant no updates got pushed to `gh-pages` branch, i.e. docs site.

## After this PR
Once script build and published the new hosted docs.