### PR TITLE
feat: dynamically import vjs module and add minified bundle to dist

### DIFF
--- a/dev/ReactApp.tsx
+++ b/dev/ReactApp.tsx
@@ -1,10 +1,10 @@
 import {createComponent} from '@lit-labs/react';
-import {IxVideo} from '../src/index';
+import {IxVideo} from './main';
 
-//eslint-disable-next-line
+/* eslint-disable @typescript-eslint/no-explicit-any */
 const React = (window as any).React as typeof import('react');
-//eslint-disable-next-line
 const ReactDOM = (window as any).ReactDOM as typeof import('react-dom');
+/* eslint-enable @typescript-eslint/no-explicit-any */
 export const Video = createComponent(React, 'ix-video', IxVideo, {
   onSeeked: 'seeked',
   onError: 'error',

--- a/dev/main.ts
+++ b/dev/main.ts
@@ -1,1 +1,1 @@
-import '~/index';
+export {IxVideo} from '~/elements/ix-video.js';

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@imgix/ix-video",
-  "version": "1.0.0",
+  "version": "1.0.1",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "@imgix/ix-video",
-      "version": "1.0.0",
+      "version": "1.0.1",
       "license": "BSD-3-Clause",
       "dependencies": {
         "lit": "^2.1.0",
@@ -44,6 +44,7 @@
         "prettier": "^2.3.2",
         "rimraf": "^3.0.2",
         "rollup": "^2.28.2",
+        "rollup-plugin-html-literals": "^1.1.5",
         "rollup-plugin-postcss": "^4.0.2",
         "rollup-plugin-postcss-lit": "^2.0.0",
         "rollup-plugin-summary": "^1.2.3",
@@ -4089,6 +4090,25 @@
         "@types/chai": "*"
       }
     },
+    "node_modules/@types/clean-css": {
+      "version": "4.2.5",
+      "resolved": "https://registry.npmjs.org/@types/clean-css/-/clean-css-4.2.5.tgz",
+      "integrity": "sha512-NEzjkGGpbs9S9fgC4abuBvTpVwE3i+Acu9BBod3PUyjDVZcNsGx61b8r2PphR61QGPnn0JHVs5ey6/I4eTrkxw==",
+      "dev": true,
+      "dependencies": {
+        "@types/node": "*",
+        "source-map": "^0.6.0"
+      }
+    },
+    "node_modules/@types/clean-css/node_modules/source-map": {
+      "version": "0.6.1",
+      "resolved": "https://registry.npmjs.org/source-map/-/source-map-0.6.1.tgz",
+      "integrity": "sha512-UjgapumWlbMhkBgzT7Ykc5YXUT46F0iKu8SGXq0bcwP5dz/h0Plj6enJqjz1Zbq2l5WaqYnrVbwWOWMyF3F47g==",
+      "dev": true,
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
     "node_modules/@types/co-body": {
       "version": "6.1.0",
       "resolved": "https://registry.npmjs.org/@types/co-body/-/co-body-6.1.0.tgz",
@@ -4213,6 +4233,17 @@
       "resolved": "https://registry.npmjs.org/@types/highlight.js/-/highlight.js-9.12.4.tgz",
       "integrity": "sha512-t2szdkwmg2JJyuCM20e8kR2X59WCE5Zkl4bzm1u1Oukjm79zpbiAv+QjnwLnuuV0WHEcX2NgUItu0pAMKuOPww==",
       "dev": true
+    },
+    "node_modules/@types/html-minifier": {
+      "version": "3.5.3",
+      "resolved": "https://registry.npmjs.org/@types/html-minifier/-/html-minifier-3.5.3.tgz",
+      "integrity": "sha512-j1P/4PcWVVCPEy5lofcHnQ6BtXz9tHGiFPWzqm7TtGuWZEfCHEP446HlkSNc9fQgNJaJZ6ewPtp2aaFla/Uerg==",
+      "dev": true,
+      "dependencies": {
+        "@types/clean-css": "*",
+        "@types/relateurl": "*",
+        "@types/uglify-js": "*"
+      }
     },
     "node_modules/@types/http-assert": {
       "version": "1.5.3",
@@ -4517,6 +4548,12 @@
       "dependencies": {
         "@types/react": "*"
       }
+    },
+    "node_modules/@types/relateurl": {
+      "version": "0.2.29",
+      "resolved": "https://registry.npmjs.org/@types/relateurl/-/relateurl-0.2.29.tgz",
+      "integrity": "sha512-QSvevZ+IRww2ldtfv1QskYsqVVVwCKQf1XbwtcyyoRvLIQzfyPhj/C+3+PKzSDRdiyejaiLgnq//XTkleorpLg==",
+      "dev": true
     },
     "node_modules/@types/resolve": {
       "version": "1.17.1",
@@ -18853,6 +18890,80 @@
         "node": ">= 4"
       }
     },
+    "node_modules/minify-html-literals": {
+      "version": "1.3.5",
+      "resolved": "https://registry.npmjs.org/minify-html-literals/-/minify-html-literals-1.3.5.tgz",
+      "integrity": "sha512-p8T8ryePRR8FVfJZLVFmM53WY25FL0moCCTycUDuAu6rf9GMLwy0gNjXBGNin3Yun7Y+tIWd28axOf0t2EpAlQ==",
+      "dev": true,
+      "dependencies": {
+        "@types/html-minifier": "^3.5.3",
+        "clean-css": "^4.2.1",
+        "html-minifier": "^4.0.0",
+        "magic-string": "^0.25.0",
+        "parse-literals": "^1.2.1"
+      }
+    },
+    "node_modules/minify-html-literals/node_modules/camel-case": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/camel-case/-/camel-case-3.0.0.tgz",
+      "integrity": "sha512-+MbKztAYHXPr1jNTSKQF52VpcFjwY5RkR7fxksV8Doo4KAYc5Fl4UJRgthBbTmEx8C54DqahhbLJkDwjI3PI/w==",
+      "dev": true,
+      "dependencies": {
+        "no-case": "^2.2.0",
+        "upper-case": "^1.1.1"
+      }
+    },
+    "node_modules/minify-html-literals/node_modules/commander": {
+      "version": "2.20.3",
+      "resolved": "https://registry.npmjs.org/commander/-/commander-2.20.3.tgz",
+      "integrity": "sha512-GpVkmM8vF2vQUkj2LvZmD35JxeJOLCwJ9cUkugyk2nuhbv3+mJvpLYYt+0+USMxE+oj+ey/lJEnhZw75x/OMcQ==",
+      "dev": true
+    },
+    "node_modules/minify-html-literals/node_modules/html-minifier": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/html-minifier/-/html-minifier-4.0.0.tgz",
+      "integrity": "sha512-aoGxanpFPLg7MkIl/DDFYtb0iWz7jMFGqFhvEDZga6/4QTjneiD8I/NXL1x5aaoCp7FSIT6h/OhykDdPsbtMig==",
+      "dev": true,
+      "dependencies": {
+        "camel-case": "^3.0.0",
+        "clean-css": "^4.2.1",
+        "commander": "^2.19.0",
+        "he": "^1.2.0",
+        "param-case": "^2.1.1",
+        "relateurl": "^0.2.7",
+        "uglify-js": "^3.5.1"
+      },
+      "bin": {
+        "html-minifier": "cli.js"
+      },
+      "engines": {
+        "node": ">=6"
+      }
+    },
+    "node_modules/minify-html-literals/node_modules/lower-case": {
+      "version": "1.1.4",
+      "resolved": "https://registry.npmjs.org/lower-case/-/lower-case-1.1.4.tgz",
+      "integrity": "sha1-miyr0bno4K6ZOkv31YdcOcQujqw=",
+      "dev": true
+    },
+    "node_modules/minify-html-literals/node_modules/no-case": {
+      "version": "2.3.2",
+      "resolved": "https://registry.npmjs.org/no-case/-/no-case-2.3.2.tgz",
+      "integrity": "sha512-rmTZ9kz+f3rCvK2TD1Ue/oZlns7OGoIWP4fc3llxxRXlOkHKoWPPWJOfFYpITabSow43QJbRIoHQXtt10VldyQ==",
+      "dev": true,
+      "dependencies": {
+        "lower-case": "^1.1.1"
+      }
+    },
+    "node_modules/minify-html-literals/node_modules/param-case": {
+      "version": "2.1.1",
+      "resolved": "https://registry.npmjs.org/param-case/-/param-case-2.1.1.tgz",
+      "integrity": "sha1-35T9jPZTHs915r75oIWPvHK+Ikc=",
+      "dev": true,
+      "dependencies": {
+        "no-case": "^2.2.0"
+      }
+    },
     "node_modules/minimalistic-assert": {
       "version": "1.0.1",
       "resolved": "https://registry.npmjs.org/minimalistic-assert/-/minimalistic-assert-1.0.1.tgz",
@@ -24000,6 +24111,15 @@
         "node": ">=4"
       }
     },
+    "node_modules/parse-literals": {
+      "version": "1.2.1",
+      "resolved": "https://registry.npmjs.org/parse-literals/-/parse-literals-1.2.1.tgz",
+      "integrity": "sha512-Ml0w104Ph2wwzuRdxrg9booVWsngXbB4bZ5T2z6WyF8b5oaNkUmBiDtahi34yUIpXD8Y13JjAK6UyIyApJ73RQ==",
+      "dev": true,
+      "dependencies": {
+        "typescript": "^2.9.2 || ^3.0.0 || ^4.0.0"
+      }
+    },
     "node_modules/parse5": {
       "version": "5.1.1",
       "resolved": "https://registry.npmjs.org/parse5/-/parse5-5.1.1.tgz",
@@ -26532,6 +26652,38 @@
       "engines": {
         "node": ">=10"
       }
+    },
+    "node_modules/rollup-plugin-html-literals": {
+      "version": "1.1.5",
+      "resolved": "https://registry.npmjs.org/rollup-plugin-html-literals/-/rollup-plugin-html-literals-1.1.5.tgz",
+      "integrity": "sha512-AceiHucrpXQDvkPT6eLQdx9E6zGe+GZwF0ihOnw9Ftxcb3KEEkw+xtAbcs9NZx6dR4BbJsg8xOEoBnmsDnyohg==",
+      "dev": true,
+      "dependencies": {
+        "@rollup/pluginutils": "^4.2.0",
+        "minify-html-literals": "^1.3.5"
+      },
+      "peerDependencies": {
+        "rollup": "^1.x.x||^2.x.x"
+      }
+    },
+    "node_modules/rollup-plugin-html-literals/node_modules/@rollup/pluginutils": {
+      "version": "4.2.1",
+      "resolved": "https://registry.npmjs.org/@rollup/pluginutils/-/pluginutils-4.2.1.tgz",
+      "integrity": "sha512-iKnFXr7NkdZAIHiIWE+BX5ULi/ucVFYWD6TbAV+rZctiRTY2PL6tsIKhoIOaoskiWAkgu+VsbXgUVDNLHf+InQ==",
+      "dev": true,
+      "dependencies": {
+        "estree-walker": "^2.0.1",
+        "picomatch": "^2.2.2"
+      },
+      "engines": {
+        "node": ">= 8.0.0"
+      }
+    },
+    "node_modules/rollup-plugin-html-literals/node_modules/estree-walker": {
+      "version": "2.0.2",
+      "resolved": "https://registry.npmjs.org/estree-walker/-/estree-walker-2.0.2.tgz",
+      "integrity": "sha512-Rfkk/Mp/DL7JVje3u18FxFujQlTNR2q6QfMSMB7AvCBx91NGj/ba3kCfza0f6dVDbw7YlRf/nDrn7pQrCCyQ/w==",
+      "dev": true
     },
     "node_modules/rollup-plugin-postcss": {
       "version": "4.0.2",
@@ -29858,7 +30010,6 @@
       "resolved": "https://registry.npmjs.org/uglify-js/-/uglify-js-3.15.4.tgz",
       "integrity": "sha512-vMOPGDuvXecPs34V74qDKk4iJ/SN4vL3Ow/23ixafENYvtrNvtbcgUeugTcUGRGsOF/5fU8/NYSL5Hyb3l1OJA==",
       "dev": true,
-      "optional": true,
       "bin": {
         "uglifyjs": "bin/uglifyjs"
       },
@@ -36152,6 +36303,24 @@
         "@types/chai": "*"
       }
     },
+    "@types/clean-css": {
+      "version": "4.2.5",
+      "resolved": "https://registry.npmjs.org/@types/clean-css/-/clean-css-4.2.5.tgz",
+      "integrity": "sha512-NEzjkGGpbs9S9fgC4abuBvTpVwE3i+Acu9BBod3PUyjDVZcNsGx61b8r2PphR61QGPnn0JHVs5ey6/I4eTrkxw==",
+      "dev": true,
+      "requires": {
+        "@types/node": "*",
+        "source-map": "^0.6.0"
+      },
+      "dependencies": {
+        "source-map": {
+          "version": "0.6.1",
+          "resolved": "https://registry.npmjs.org/source-map/-/source-map-0.6.1.tgz",
+          "integrity": "sha512-UjgapumWlbMhkBgzT7Ykc5YXUT46F0iKu8SGXq0bcwP5dz/h0Plj6enJqjz1Zbq2l5WaqYnrVbwWOWMyF3F47g==",
+          "dev": true
+        }
+      }
+    },
     "@types/co-body": {
       "version": "6.1.0",
       "resolved": "https://registry.npmjs.org/@types/co-body/-/co-body-6.1.0.tgz",
@@ -36276,6 +36445,17 @@
       "resolved": "https://registry.npmjs.org/@types/highlight.js/-/highlight.js-9.12.4.tgz",
       "integrity": "sha512-t2szdkwmg2JJyuCM20e8kR2X59WCE5Zkl4bzm1u1Oukjm79zpbiAv+QjnwLnuuV0WHEcX2NgUItu0pAMKuOPww==",
       "dev": true
+    },
+    "@types/html-minifier": {
+      "version": "3.5.3",
+      "resolved": "https://registry.npmjs.org/@types/html-minifier/-/html-minifier-3.5.3.tgz",
+      "integrity": "sha512-j1P/4PcWVVCPEy5lofcHnQ6BtXz9tHGiFPWzqm7TtGuWZEfCHEP446HlkSNc9fQgNJaJZ6ewPtp2aaFla/Uerg==",
+      "dev": true,
+      "requires": {
+        "@types/clean-css": "*",
+        "@types/relateurl": "*",
+        "@types/uglify-js": "*"
+      }
     },
     "@types/http-assert": {
       "version": "1.5.3",
@@ -36580,6 +36760,12 @@
       "requires": {
         "@types/react": "*"
       }
+    },
+    "@types/relateurl": {
+      "version": "0.2.29",
+      "resolved": "https://registry.npmjs.org/@types/relateurl/-/relateurl-0.2.29.tgz",
+      "integrity": "sha512-QSvevZ+IRww2ldtfv1QskYsqVVVwCKQf1XbwtcyyoRvLIQzfyPhj/C+3+PKzSDRdiyejaiLgnq//XTkleorpLg==",
+      "dev": true
     },
     "@types/resolve": {
       "version": "1.17.1",
@@ -47898,6 +48084,76 @@
         }
       }
     },
+    "minify-html-literals": {
+      "version": "1.3.5",
+      "resolved": "https://registry.npmjs.org/minify-html-literals/-/minify-html-literals-1.3.5.tgz",
+      "integrity": "sha512-p8T8ryePRR8FVfJZLVFmM53WY25FL0moCCTycUDuAu6rf9GMLwy0gNjXBGNin3Yun7Y+tIWd28axOf0t2EpAlQ==",
+      "dev": true,
+      "requires": {
+        "@types/html-minifier": "^3.5.3",
+        "clean-css": "^4.2.1",
+        "html-minifier": "^4.0.0",
+        "magic-string": "^0.25.0",
+        "parse-literals": "^1.2.1"
+      },
+      "dependencies": {
+        "camel-case": {
+          "version": "3.0.0",
+          "resolved": "https://registry.npmjs.org/camel-case/-/camel-case-3.0.0.tgz",
+          "integrity": "sha512-+MbKztAYHXPr1jNTSKQF52VpcFjwY5RkR7fxksV8Doo4KAYc5Fl4UJRgthBbTmEx8C54DqahhbLJkDwjI3PI/w==",
+          "dev": true,
+          "requires": {
+            "no-case": "^2.2.0",
+            "upper-case": "^1.1.1"
+          }
+        },
+        "commander": {
+          "version": "2.20.3",
+          "resolved": "https://registry.npmjs.org/commander/-/commander-2.20.3.tgz",
+          "integrity": "sha512-GpVkmM8vF2vQUkj2LvZmD35JxeJOLCwJ9cUkugyk2nuhbv3+mJvpLYYt+0+USMxE+oj+ey/lJEnhZw75x/OMcQ==",
+          "dev": true
+        },
+        "html-minifier": {
+          "version": "4.0.0",
+          "resolved": "https://registry.npmjs.org/html-minifier/-/html-minifier-4.0.0.tgz",
+          "integrity": "sha512-aoGxanpFPLg7MkIl/DDFYtb0iWz7jMFGqFhvEDZga6/4QTjneiD8I/NXL1x5aaoCp7FSIT6h/OhykDdPsbtMig==",
+          "dev": true,
+          "requires": {
+            "camel-case": "^3.0.0",
+            "clean-css": "^4.2.1",
+            "commander": "^2.19.0",
+            "he": "^1.2.0",
+            "param-case": "^2.1.1",
+            "relateurl": "^0.2.7",
+            "uglify-js": "^3.5.1"
+          }
+        },
+        "lower-case": {
+          "version": "1.1.4",
+          "resolved": "https://registry.npmjs.org/lower-case/-/lower-case-1.1.4.tgz",
+          "integrity": "sha1-miyr0bno4K6ZOkv31YdcOcQujqw=",
+          "dev": true
+        },
+        "no-case": {
+          "version": "2.3.2",
+          "resolved": "https://registry.npmjs.org/no-case/-/no-case-2.3.2.tgz",
+          "integrity": "sha512-rmTZ9kz+f3rCvK2TD1Ue/oZlns7OGoIWP4fc3llxxRXlOkHKoWPPWJOfFYpITabSow43QJbRIoHQXtt10VldyQ==",
+          "dev": true,
+          "requires": {
+            "lower-case": "^1.1.1"
+          }
+        },
+        "param-case": {
+          "version": "2.1.1",
+          "resolved": "https://registry.npmjs.org/param-case/-/param-case-2.1.1.tgz",
+          "integrity": "sha1-35T9jPZTHs915r75oIWPvHK+Ikc=",
+          "dev": true,
+          "requires": {
+            "no-case": "^2.2.0"
+          }
+        }
+      }
+    },
     "minimalistic-assert": {
       "version": "1.0.1",
       "resolved": "https://registry.npmjs.org/minimalistic-assert/-/minimalistic-assert-1.0.1.tgz",
@@ -51838,6 +52094,15 @@
         "json-parse-better-errors": "^1.0.1"
       }
     },
+    "parse-literals": {
+      "version": "1.2.1",
+      "resolved": "https://registry.npmjs.org/parse-literals/-/parse-literals-1.2.1.tgz",
+      "integrity": "sha512-Ml0w104Ph2wwzuRdxrg9booVWsngXbB4bZ5T2z6WyF8b5oaNkUmBiDtahi34yUIpXD8Y13JjAK6UyIyApJ73RQ==",
+      "dev": true,
+      "requires": {
+        "typescript": "^2.9.2 || ^3.0.0 || ^4.0.0"
+      }
+    },
     "parse5": {
       "version": "5.1.1",
       "resolved": "https://registry.npmjs.org/parse5/-/parse5-5.1.1.tgz",
@@ -53744,6 +54009,34 @@
             "source-map": "~0.7.2",
             "source-map-support": "~0.5.19"
           }
+        }
+      }
+    },
+    "rollup-plugin-html-literals": {
+      "version": "1.1.5",
+      "resolved": "https://registry.npmjs.org/rollup-plugin-html-literals/-/rollup-plugin-html-literals-1.1.5.tgz",
+      "integrity": "sha512-AceiHucrpXQDvkPT6eLQdx9E6zGe+GZwF0ihOnw9Ftxcb3KEEkw+xtAbcs9NZx6dR4BbJsg8xOEoBnmsDnyohg==",
+      "dev": true,
+      "requires": {
+        "@rollup/pluginutils": "^4.2.0",
+        "minify-html-literals": "^1.3.5"
+      },
+      "dependencies": {
+        "@rollup/pluginutils": {
+          "version": "4.2.1",
+          "resolved": "https://registry.npmjs.org/@rollup/pluginutils/-/pluginutils-4.2.1.tgz",
+          "integrity": "sha512-iKnFXr7NkdZAIHiIWE+BX5ULi/ucVFYWD6TbAV+rZctiRTY2PL6tsIKhoIOaoskiWAkgu+VsbXgUVDNLHf+InQ==",
+          "dev": true,
+          "requires": {
+            "estree-walker": "^2.0.1",
+            "picomatch": "^2.2.2"
+          }
+        },
+        "estree-walker": {
+          "version": "2.0.2",
+          "resolved": "https://registry.npmjs.org/estree-walker/-/estree-walker-2.0.2.tgz",
+          "integrity": "sha512-Rfkk/Mp/DL7JVje3u18FxFujQlTNR2q6QfMSMB7AvCBx91NGj/ba3kCfza0f6dVDbw7YlRf/nDrn7pQrCCyQ/w==",
+          "dev": true
         }
       }
     },
@@ -56437,8 +56730,7 @@
       "version": "3.15.4",
       "resolved": "https://registry.npmjs.org/uglify-js/-/uglify-js-3.15.4.tgz",
       "integrity": "sha512-vMOPGDuvXecPs34V74qDKk4iJ/SN4vL3Ow/23ixafENYvtrNvtbcgUeugTcUGRGsOF/5fU8/NYSL5Hyb3l1OJA==",
-      "dev": true,
-      "optional": true
+      "dev": true
     },
     "unbox-primitive": {
       "version": "1.0.2",

--- a/package.json
+++ b/package.json
@@ -9,10 +9,10 @@
   "bugs": {
     "url": "https://github.com/imgix/ix-video/issues"
   },
-  "main": "/dist/index.bundled.js",
-  "module": "/dist/index.bundled.js",
-  "jsnext:main": "/dist/index.bundled.js",
-  "unpkg": "dist/index.bundled.js",
+  "main": "/dist/esm/ix-video.js",
+  "module": "/dist/esm/ix-video.js",
+  "jsnext:main": "/dist/esm/ix-video.js",
+  "unpkg": "dist/min/ix-video.js",
   "type": "module",
   "files": [
     "/dist",
@@ -29,8 +29,11 @@
     "videojs/": "./node_modules/video.js/dist/"
   },
   "scripts": {
-    "build": "rollup -c rollup.config.mjs",
-    "build:watch": "rollup -c rollup.config.mjs --watch",
+    "build": " npm run clean:esm && npm run clean:min && npm run build:esm && npm run build:min",
+    "build:esm": " npm run clean:esm && rollup -c rollup.config.mjs",
+    "build:esm:watch": " npm run clean:esm && rollup -c rollup.config.mjs --watch",
+    "build:min": "export VJS_BUNDLE_TYPE=minified || set VJS_BUNDLE_TYPE=minified&& npm run clean:min && rollup -c rollup.config.mjs",
+    "build:min:watch": "export VJS_BUNDLE_TYPE=minified || set VJS_BUNDLE_TYPE=minified&& npm run clean:min && rollup -c rollup.config.mjs --watch",
     "dev": "vite --config ./dev/vite.config.ts",
     "dev:prod": "vite --mode production --config ./dev/vite.config.ts",
     "docs:dev": "cd docs && npm run dev",
@@ -48,7 +51,8 @@
     "test:e2e": "concurrently --n \"vite,cypress\" --p \"[{name}]\" -c \"green,yellow\" \"npm:dev\" \"npm:cypress:run\" -k",
     "test:e2e:watch": "concurrently --n \"vite,cypress\" --p \"[{name}]\" -c \"green,yellow\" \"npm:dev\" \"npm run cypress:run:watch\" -k",
     "test:e2e:prod": "concurrently --n \"vite,cypress\" --p \"[{name}]\" -c \"green,yellow\" \"npm:dev\" \"npm run cypress:run:prod\" -k",
-    "checksize": "rollup -c ; cat index.bundled.js | gzip -9 | wc -c ; rm index.bundled.js",
+    "clean:min": "rm -rf dist/min",
+    "clean:esm": "rm -rf dist/esm",
     "cypress": "concurrently --n \"vite,cypress\" --p \"[{name}]\" -c \"green,yellow\" \"npm:cypress:open\" \"npm:dev\" -k",
     "cypress:open": "cypress open",
     "cypress:open-ct": "cypress open-ct",
@@ -107,6 +111,7 @@
     "prettier": "^2.3.2",
     "rimraf": "^3.0.2",
     "rollup": "^2.28.2",
+    "rollup-plugin-html-literals": "^1.1.5",
     "rollup-plugin-postcss": "^4.0.2",
     "rollup-plugin-postcss-lit": "^2.0.0",
     "rollup-plugin-summary": "^1.2.3",
@@ -240,11 +245,11 @@
         {
           "assets": [
             {
-              "path": "dist/index.bundled.js",
+              "path": "dist/esm/ix-video.js",
               "label": "UMD/CJS build"
             },
             {
-              "path": "dist/index.bundled.ts.map",
+              "path": "dist/esm/ix-video.ts.map",
               "label": "UMD/CJS build sourcemap"
             },
             {

--- a/rollup.config.mjs
+++ b/rollup.config.mjs
@@ -11,29 +11,74 @@ import process from 'process';
 import postcss from 'rollup-plugin-postcss';
 import postcssLit from 'rollup-plugin-postcss-lit';
 import summary from 'rollup-plugin-summary';
+import {terser} from 'rollup-plugin-terser';
 import ts from 'rollup-plugin-ts';
 
 const devMode = process.env.NODE_ENV === 'development';
-console.log(`${devMode ? 'development' : 'production'} mode bundle`);
+const vjsBundleType = process.env.VJS_BUNDLE_TYPE || 'esm';
 
-export default {
-  input: './src/index.ts',
-  output: {
-    file: './dist/index.bundled.js',
-    format: 'esm',
+const buildConfig = {
+  minified: {
+    // minified bundle
+    input: './src/elements/ix-video.ts',
+    output: {
+      dir: './dist/min/',
+      format: 'esm',
+    },
+    onwarn(warning) {
+      if (warning.code !== 'THIS_IS_UNDEFINED') {
+        console.error(`(!) ${warning.message}`);
+      }
+    },
+    plugins: [
+      ts(),
+      replace({
+        'Reflect.decorate': 'undefined',
+        'process.env.VJS_BUNDLE_TYPE': JSON.stringify(vjsBundleType),
+        preventAssignment: true,
+      }),
+      resolve(),
+      postcss(),
+      postcssLit(),
+      // Minify JS
+      terser({
+        ecma: 2020,
+        module: true,
+        warnings: true,
+      }),
+      commonjs(),
+      summary(),
+    ],
   },
-  onwarn(warning) {
-    if (warning.code !== 'THIS_IS_UNDEFINED') {
-      console.error(`(!) ${warning.message}`);
-    }
+  esm: {
+    // non-minified bundle
+    input: './src/elements/ix-video.ts',
+    output: {
+      dir: './dist/esm/',
+      format: 'esm',
+    },
+    onwarn(warning) {
+      if (warning.code !== 'THIS_IS_UNDEFINED') {
+        console.error(`(!) ${warning.message}`);
+      }
+    },
+    plugins: [
+      replace({
+        'video.js/dist/video.min.js': 'video.js',
+        preventAssignment: true,
+      }),
+      ts(),
+      resolve(),
+      postcss(),
+      postcssLit(),
+      commonjs(),
+      summary(),
+    ],
   },
-  plugins: [
-    ts(),
-    replace({'Reflect.decorate': 'undefined', preventAssignment: true}),
-    resolve(),
-    postcss(),
-    postcssLit(),
-    commonjs(),
-    summary(),
-  ],
 };
+console.log(
+  `Building ix-video ${devMode ? 'development' : 'production'} bundle`
+);
+console.log(`Building video.js ${vjsBundleType} bundle`);
+
+export default buildConfig[vjsBundleType];

--- a/src/elements/ix-video.ts
+++ b/src/elements/ix-video.ts
@@ -1,10 +1,10 @@
 import {html, LitElement, PropertyValues} from 'lit';
 import {customElement, property, state} from 'lit/decorators.js';
 import {createRef, ref} from 'lit/directives/ref.js';
-import videojs, {VideoJsPlayerOptions} from 'video.js';
-// eslint-disable-next-line @typescript-eslint/ban-ts-comment
+import {VideoJsPlayer, VideoJsPlayerOptions} from 'video.js';
+// eslint-disable-next-line
 // @ts-ignore - video-js.css is not typed
-import vjsStyles from 'video.js/dist/video-js.css';
+import vjsStyles from 'video.js/dist/video-js.min.css';
 import {DefaultVideoEventsMap} from '~/constants';
 import {convertDataSetupStringToObject} from '~/converters';
 import {
@@ -14,6 +14,14 @@ import {
   spreadHostAttributesToElement,
 } from '~/helpers';
 import {DataSetup} from '~/types';
+// dynamically import to avoid blocking the main thread
+declare type videojsT = typeof import('video.js').default;
+const videojs: videojsT = await (async () => {
+  // eslint-disable-next-line
+  // @ts-ignore - the minified version of video.js is not typed
+  const vjs = await import('video.js/dist/video.min.js');
+  return vjs.default;
+})();
 
 /**
  * ix-video is a custom element that can be used to display a video.
@@ -31,7 +39,7 @@ import {DataSetup} from '~/types';
 export class IxVideo extends LitElement {
   // Will insert a style tag to the document head. If we had the shadow-dom
   // enabled, this would mean the styles would be scoped to this component.
-  static override styles = vjsStyles;
+  static override styles = [vjsStyles];
   /**
    * ------------------------------------------------------------------------
    * Instance Variables
@@ -115,7 +123,7 @@ export class IxVideo extends LitElement {
    * video player when the element is removed from the DOM.
    */
   uid = generateUid();
-  vjsPlayer: videojs.Player | undefined = undefined;
+  vjsPlayer: VideoJsPlayer | undefined = undefined;
 
   /**
    * ------------------------------------------------------------------------
@@ -334,7 +342,6 @@ export class IxVideo extends LitElement {
     // Initialize the videojs player, which will modify the DOM to add the
     // video player and its controls.
     const vjsPlayer = videojs(player, options as VideoJsPlayerOptions, () => {
-      console.log('ix-video: player ready');
       // Prevent VJS error logging in console
       videojs.log.level('off');
       // Update the player poster to match the video element dimensions

--- a/src/index.ts
+++ b/src/index.ts
@@ -1,1 +1,0 @@
-export {IxVideo} from './elements/ix-video';

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -3,7 +3,7 @@
     // Ensure that Babel can safely transpile files in the TypeScript project
     "isolatedModules": true,
     "target": "es2019",
-    "module": "es2020",
+    "module": "esnext",
     "lib": ["es2020", "DOM", "DOM.Iterable"],
     "declaration": true,
     "declarationMap": true,


### PR DESCRIPTION
# Before this PR:

Importing the vjs bundle was load-blocking for the rest of our code. There was no way to tell the browser to load it and our custom element dynamically.

# After this PR:

We export a `mini/` and `esm/` `ix-video.js` module in `dist/`.

Also, the vjs bundle is imported dynamically, so it doesn't block the browser from loading the rest of the module.

While the majority of the code won't _execute_ until after vjs module has loaded, it will have already been loaded. So the only bottleneck for execution becomes the player tech's bundle load time.

This opens the door for, in the future, allowing users to host their own bundle of the player that's more aggressively minified than what we can offer.

This also allows CDNs like unpckg to more aggressively bundle the split deps.