### PR TITLE
docs: change readme usage links to abs urls

### DIFF
--- a/README.md
+++ b/README.md
@@ -40,7 +40,7 @@ Or add it from a CDN:
 
 ## Usage
 
-Look at our docs to see how to us this inside your [React](/docs/src/overview/react.md), [Vue](/docs/src/overview/vue.md), or other [web-apps](/docs/src/overview/static.md).
+Look at our docs to see how to us this inside your [React](https://github.com/imgix/ix-video/blob/main/docs/src/overview/react.md), [Vue](https://github.com/imgix/ix-video/blob/main/docs/src/overview/vue.md), or other [web-apps](https://github.com/imgix/ix-video/blob/main/docs/src/overview/static.md).
 
 ### Using `<ix-video>` on a static HTML static page
 


### PR DESCRIPTION
The API docs page on imgix doesn't work with relative URLs for the MD
files. This commit changes them to absolute URLs.