### PR TITLE
[RFC] feat: use imgix js-core to format ixlib param

### DIFF
--- a/dev/index.html
+++ b/dev/index.html
@@ -14,6 +14,7 @@
         data-test-id="ix-video-with-container"
         source="https://assets.imgix.video/videos/girl-reading-book-in-library.mp4"
         controls
+        poster="https://sdk-test.imgix.net/amsterdam.jpg"
       ></ix-video>
     </div>
     <script type="module" src="./main.ts"></script>

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,14 +1,15 @@
 {
   "name": "@imgix/ix-video",
-  "version": "1.0.1",
+  "version": "1.1.0",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "@imgix/ix-video",
-      "version": "1.0.1",
+      "version": "1.1.0",
       "license": "BSD-3-Clause",
       "dependencies": {
+        "@imgix/js-core": "^3.6.0",
         "lit": "^2.1.0",
         "video.js": "^7.18.1"
       },
@@ -2098,6 +2099,16 @@
       "resolved": "https://registry.npmjs.org/@humanwhocodes/object-schema/-/object-schema-1.2.0.tgz",
       "integrity": "sha512-wdppn25U8z/2yiaT6YGquE6X8sSv7hNMWSXYSSU1jGv/yd6XqjXgTDJ8KP4NgjTXfJ3GbRjeeb8RTV7a/VpM+w==",
       "dev": true
+    },
+    "node_modules/@imgix/js-core": {
+      "version": "3.6.0",
+      "resolved": "https://registry.npmjs.org/@imgix/js-core/-/js-core-3.6.0.tgz",
+      "integrity": "sha512-00qsHfyk7HvSj5NJdLA5O2QeBUVPM0khpO0qQvyMBmVP9aZaYJWkMd1IXQm0TUvcI1+Ja2mvdPzRYULFCiQBTg==",
+      "dependencies": {
+        "js-base64": "~3.7.0",
+        "md5": "^2.2.1",
+        "ufo": "^0.7.10"
+      }
     },
     "node_modules/@istanbuljs/schema": {
       "version": "0.1.3",
@@ -8959,6 +8970,14 @@
         "node": ">=6"
       }
     },
+    "node_modules/charenc": {
+      "version": "0.0.2",
+      "resolved": "https://registry.npmjs.org/charenc/-/charenc-0.0.2.tgz",
+      "integrity": "sha512-yrLQ/yVUFXkzg7EDQsPieE/53+0RlaWTs+wBrvW36cyilJ2SaDWfl4Yj7MtLTXleV9uEKefbAGUPv2/iWSooRA==",
+      "engines": {
+        "node": "*"
+      }
+    },
     "node_modules/check-more-types": {
       "version": "2.24.0",
       "resolved": "https://registry.npmjs.org/check-more-types/-/check-more-types-2.24.0.tgz",
@@ -10645,6 +10664,14 @@
       },
       "engines": {
         "node": ">=10.0.0"
+      }
+    },
+    "node_modules/crypt": {
+      "version": "0.0.2",
+      "resolved": "https://registry.npmjs.org/crypt/-/crypt-0.0.2.tgz",
+      "integrity": "sha512-mCxBlsHFYh9C+HVpiEacem8FEBnMXgU9gy4zmNC+SXAZNB/1idgp/aulFJ4FgCi7GPEVbfyng092GqL2k2rmow==",
+      "engines": {
+        "node": "*"
       }
     },
     "node_modules/crypto-browserify": {
@@ -15925,8 +15952,7 @@
     "node_modules/is-buffer": {
       "version": "1.1.6",
       "resolved": "https://registry.npmjs.org/is-buffer/-/is-buffer-1.1.6.tgz",
-      "integrity": "sha512-NcdALwpXkTm5Zvvbk7owOUSvVvBKDgKP5/ewfXEznmQFfs4ZRmanOeKBTjRVjka3QFoN6XJ+9F3USqfHqTaU5w==",
-      "dev": true
+      "integrity": "sha512-NcdALwpXkTm5Zvvbk7owOUSvVvBKDgKP5/ewfXEznmQFfs4ZRmanOeKBTjRVjka3QFoN6XJ+9F3USqfHqTaU5w=="
     },
     "node_modules/is-callable": {
       "version": "1.2.4",
@@ -16652,6 +16678,11 @@
       "engines": {
         "node": ">= 10.13.0"
       }
+    },
+    "node_modules/js-base64": {
+      "version": "3.7.2",
+      "resolved": "https://registry.npmjs.org/js-base64/-/js-base64-3.7.2.tgz",
+      "integrity": "sha512-NnRs6dsyqUXejqk/yv2aiXlAvOs56sLkX6nUdeaNezI5LFFLlsZjOThmwnrcwh5ZZRwZlCMnVAY3CvhIhoVEKQ=="
     },
     "node_modules/js-tokens": {
       "version": "4.0.0",
@@ -18500,6 +18531,16 @@
       },
       "funding": {
         "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/md5": {
+      "version": "2.3.0",
+      "resolved": "https://registry.npmjs.org/md5/-/md5-2.3.0.tgz",
+      "integrity": "sha512-T1GITYmFaKuO91vxyoQMFETst+O71VUPEU3ze5GNzDm0OWdP8v1ziTaAEPUr/3kLsY3Sftgz242A1SetQiDL7g==",
+      "dependencies": {
+        "charenc": "0.0.2",
+        "crypt": "0.0.2",
+        "is-buffer": "~1.1.6"
       }
     },
     "node_modules/md5.js": {
@@ -30063,6 +30104,11 @@
       "integrity": "sha512-8Y75pvTYkLJW2hWQHXxoqRgV7qb9B+9vFEtidML+7koHUFapnVJAZ6cKs+Qjz5Aw3aZWHMC6u0wJE3At+nSGwA==",
       "dev": true
     },
+    "node_modules/ufo": {
+      "version": "0.7.11",
+      "resolved": "https://registry.npmjs.org/ufo/-/ufo-0.7.11.tgz",
+      "integrity": "sha512-IT3q0lPvtkqQ8toHQN/BkOi4VIqoqheqM1FnkNWT9y0G8B3xJhwnoKBu5OHx8zHDOvveQzfKuFowJ0VSARiIDg=="
+    },
     "node_modules/uglify-js": {
       "version": "3.15.4",
       "resolved": "https://registry.npmjs.org/uglify-js/-/uglify-js-3.15.4.tgz",
@@ -34728,6 +34774,16 @@
       "resolved": "https://registry.npmjs.org/@humanwhocodes/object-schema/-/object-schema-1.2.0.tgz",
       "integrity": "sha512-wdppn25U8z/2yiaT6YGquE6X8sSv7hNMWSXYSSU1jGv/yd6XqjXgTDJ8KP4NgjTXfJ3GbRjeeb8RTV7a/VpM+w==",
       "dev": true
+    },
+    "@imgix/js-core": {
+      "version": "3.6.0",
+      "resolved": "https://registry.npmjs.org/@imgix/js-core/-/js-core-3.6.0.tgz",
+      "integrity": "sha512-00qsHfyk7HvSj5NJdLA5O2QeBUVPM0khpO0qQvyMBmVP9aZaYJWkMd1IXQm0TUvcI1+Ja2mvdPzRYULFCiQBTg==",
+      "requires": {
+        "js-base64": "~3.7.0",
+        "md5": "^2.2.1",
+        "ufo": "^0.7.10"
+      }
     },
     "@istanbuljs/schema": {
       "version": "0.1.3",
@@ -40333,6 +40389,11 @@
       "integrity": "sha512-Y4kiDb+AM4Ecy58YkuZrrSRJBDQdQ2L+NyS1vHHFtNtUjgutcZfx3yp1dAONI/oPaPmyGfCLx5CxL+zauIMyKQ==",
       "dev": true
     },
+    "charenc": {
+      "version": "0.0.2",
+      "resolved": "https://registry.npmjs.org/charenc/-/charenc-0.0.2.tgz",
+      "integrity": "sha512-yrLQ/yVUFXkzg7EDQsPieE/53+0RlaWTs+wBrvW36cyilJ2SaDWfl4Yj7MtLTXleV9uEKefbAGUPv2/iWSooRA=="
+    },
     "check-more-types": {
       "version": "2.24.0",
       "resolved": "https://registry.npmjs.org/check-more-types/-/check-more-types-2.24.0.tgz",
@@ -41690,6 +41751,11 @@
       "requires": {
         "@types/node": "^16.11.7"
       }
+    },
+    "crypt": {
+      "version": "0.0.2",
+      "resolved": "https://registry.npmjs.org/crypt/-/crypt-0.0.2.tgz",
+      "integrity": "sha512-mCxBlsHFYh9C+HVpiEacem8FEBnMXgU9gy4zmNC+SXAZNB/1idgp/aulFJ4FgCi7GPEVbfyng092GqL2k2rmow=="
     },
     "crypto-browserify": {
       "version": "3.12.0",
@@ -45739,8 +45805,7 @@
     "is-buffer": {
       "version": "1.1.6",
       "resolved": "https://registry.npmjs.org/is-buffer/-/is-buffer-1.1.6.tgz",
-      "integrity": "sha512-NcdALwpXkTm5Zvvbk7owOUSvVvBKDgKP5/ewfXEznmQFfs4ZRmanOeKBTjRVjka3QFoN6XJ+9F3USqfHqTaU5w==",
-      "dev": true
+      "integrity": "sha512-NcdALwpXkTm5Zvvbk7owOUSvVvBKDgKP5/ewfXEznmQFfs4ZRmanOeKBTjRVjka3QFoN6XJ+9F3USqfHqTaU5w=="
     },
     "is-callable": {
       "version": "1.2.4",
@@ -46261,6 +46326,11 @@
         "merge-stream": "^2.0.0",
         "supports-color": "^7.0.0"
       }
+    },
+    "js-base64": {
+      "version": "3.7.2",
+      "resolved": "https://registry.npmjs.org/js-base64/-/js-base64-3.7.2.tgz",
+      "integrity": "sha512-NnRs6dsyqUXejqk/yv2aiXlAvOs56sLkX6nUdeaNezI5LFFLlsZjOThmwnrcwh5ZZRwZlCMnVAY3CvhIhoVEKQ=="
     },
     "js-tokens": {
       "version": "4.0.0",
@@ -47821,6 +47891,16 @@
           "integrity": "sha512-yGSza74xk0UG8k+pLh5oeoYirvIiWo5t0/o3zHHAO2tRDiZcxWP7fywNlXhqb6/r6sWvwi+RsyQMWhVLe4BVuA==",
           "dev": true
         }
+      }
+    },
+    "md5": {
+      "version": "2.3.0",
+      "resolved": "https://registry.npmjs.org/md5/-/md5-2.3.0.tgz",
+      "integrity": "sha512-T1GITYmFaKuO91vxyoQMFETst+O71VUPEU3ze5GNzDm0OWdP8v1ziTaAEPUr/3kLsY3Sftgz242A1SetQiDL7g==",
+      "requires": {
+        "charenc": "0.0.2",
+        "crypt": "0.0.2",
+        "is-buffer": "~1.1.6"
       }
     },
     "md5.js": {
@@ -56815,6 +56895,11 @@
       "resolved": "https://registry.npmjs.org/uc.micro/-/uc.micro-1.0.6.tgz",
       "integrity": "sha512-8Y75pvTYkLJW2hWQHXxoqRgV7qb9B+9vFEtidML+7koHUFapnVJAZ6cKs+Qjz5Aw3aZWHMC6u0wJE3At+nSGwA==",
       "dev": true
+    },
+    "ufo": {
+      "version": "0.7.11",
+      "resolved": "https://registry.npmjs.org/ufo/-/ufo-0.7.11.tgz",
+      "integrity": "sha512-IT3q0lPvtkqQ8toHQN/BkOi4VIqoqheqM1FnkNWT9y0G8B3xJhwnoKBu5OHx8zHDOvveQzfKuFowJ0VSARiIDg=="
     },
     "uglify-js": {
       "version": "3.15.4",

--- a/package.json
+++ b/package.json
@@ -84,6 +84,7 @@
   ],
   "license": "BSD-3-Clause",
   "dependencies": {
+    "@imgix/js-core": "^3.6.0",
     "lit": "^2.1.0",
     "video.js": "^7.18.1"
   },

--- a/src/elements/ix-video.ts
+++ b/src/elements/ix-video.ts
@@ -5,6 +5,7 @@ import type {VideoJsPlayer, VideoJsPlayerOptions} from 'video.js';
 // eslint-disable-next-line
 // @ts-ignore - video-js.css is not typed
 import vjsStyles from 'video.js/dist/video-js.min.css';
+import imgixClient from '@imgix/js-core';
 // eslint-disable-next-line
 // @ts-ignore - the minified version of video.js is not typed
 import videojs from 'video.js/dist/video.min.js';
@@ -17,7 +18,6 @@ import {
   spreadHostAttributesToElement,
 } from '~/helpers';
 import {DataSetup, VideoJsT} from '~/types';
-
 /**
  * ix-video is a custom element that can be used to display a video.
  * It wraps the video.js player in a LitElement.
@@ -69,7 +69,19 @@ export class IxVideo extends LitElement {
   /**
    * The source of the video
    */
-  @property({reflect: true})
+  @property({
+    reflect: true,
+    converter: (value: string | null) => {
+      if (!value) {
+        return value;
+      }
+      return imgixClient._buildURL(
+        value,
+        {ixlib: 'foobar-123'},
+        {includeLibraryParam: false}
+      );
+    },
+  })
   source: string | undefined = undefined;
 
   /**

--- a/src/elements/ix-video.ts
+++ b/src/elements/ix-video.ts
@@ -265,7 +265,11 @@ export class IxVideo extends LitElement {
     const width = this.width || this.videoRef.value?.offsetWidth || '';
     const height = this.height || this.videoRef.value?.offsetHeight || '';
     if (this.poster?.includes('://')) {
-      return `${this.poster}?w=${width}&h=${height}`;
+      return imgixClient._buildURL(
+        this.poster,
+        {w: width, h: height, ixlib: 'foobar-123'},
+        {includeLibraryParam: false}
+      );
     }
     return null;
   };


### PR DESCRIPTION
## Problem
We need a way to add `ixlib` to the video source URL and poster source URL.

## Proposed solution
Implement a quick fix by leaning on what js-core already does so well re: param parsing.

## Considered alternatives
Creating a `params` property that gets read/written to by user and us. Then, just before making the request to the video/image asset, format the URL with said `params`.

This was discarded because of the need to provide two `params` props. One for the video and one for the poster. I think a more in-depth discussion and considerable more time is needed to do that prop right.

## Shortcomings
We might have users duplicating deps/functionality if they need to add params to their posters/video URLs prior to our doing the same behind the scenes.

### Example output:
Video source URL:
`https://assets.imgix.video/videos/girl-reading-book-in-library.mp4?ixlib=foobar-123`

```html
<!-- poster image -->
<div class="vjs-poster" tabindex="-1" aria-disabled="false" style="background-image: url(&quot;https://sdk-test.imgix.net/amsterdam.jpg?w=480&amp;h=270&amp;ixlib=foobar-123&quot;);"></div>
```