### PR TITLE
fix: ensure source URL is formatted in updated hook 

### DIFF
--- a/cypress/integration/ix-video/poster.spec.ts
+++ b/cypress/integration/ix-video/poster.spec.ts
@@ -18,8 +18,12 @@ context('ix-video: poster', () => {
     it('should append width/height params to poster URL equal to video size', () => {
       cy.get(ixVideoTag).then(($ixVideo) => {
         const videoTag = $ixVideo.find('[part=video]');
-        const videoTagWith = videoTag.css('width').split('px')[0];
-        const videoTagHeight = videoTag.css('height').split('px')[0];
+        const videoTagWith = parseFloat(
+          videoTag.css('width').split('px')[0]
+        ).toFixed(0);
+        const videoTagHeight = parseFloat(
+          videoTag.css('height').split('px')[0]
+        ).toFixed(0);
         cy.get('.vjs-poster').should(
           'have.css',
           'background-image',

--- a/src/elements/ix-video.ts
+++ b/src/elements/ix-video.ts
@@ -304,7 +304,9 @@ export class IxVideo extends LitElement {
     changed.forEach((_, propName) => {
       if (propName === 'source') {
         this.vjsPlayer?.src(
-          this.source ? [{src: this.source, type: this.type}] : []
+          this.source
+            ? [{src: this._buildURL(this.source), type: this.type}]
+            : []
         );
       }
       if (propName === 'controls') {


### PR DESCRIPTION
This commit addresses an issue where the `updated()` Lifecycle Hook wasn't formatting the `source` using the `_buildURL` function. This meant the imgix params, ie ixlib, were not getting appended.