### PR TITLE
test: parse cypress css float values 

### DIFF
--- a/cypress/integration/ix-video/poster.spec.ts
+++ b/cypress/integration/ix-video/poster.spec.ts
@@ -34,8 +34,12 @@ context('ix-video: poster', () => {
     it('should not accept relative URLs', () => {
       cy.get(ixVideoTag).then(($ixVideo) => {
         const videoTag = $ixVideo.find('[part=video]');
-        const videoTagWith = videoTag.css('width').split('px')[0];
-        const videoTagHeight = videoTag.css('height').split('px')[0];
+        const videoTagWith = parseFloat(
+          videoTag.css('width').split('px')[0]
+        ).toFixed(0);
+        const videoTagHeight = parseFloat(
+          videoTag.css('height').split('px')[0]
+        ).toFixed(0);
         $ixVideo.attr('poster', '../../fixtures/amsterdam.jpg');
         cy.get('.vjs-poster').should(
           'have.css',


### PR DESCRIPTION
Related to PR https://github.com/imgix/ix-video/pull/23. This commit adds the changes to the other poster test as well. This way, the expected result is rounded to the nearest integer, since it's what the "actual" value evaluates to as well.