### PR TITLE
fix: only update source in the updated hook

### DIFF
--- a/src/elements/ix-video.ts
+++ b/src/elements/ix-video.ts
@@ -230,9 +230,6 @@ export class IxVideo extends LitElement {
       width: this.width ?? '',
       height: this.height ?? '',
       controls: this.controls,
-      sources: this.source
-        ? [{src: this._buildURL(this.source), type: this.type}]
-        : [],
       fluid: !this.fixed,
       ...this.dataSetup,
     };
@@ -345,7 +342,7 @@ export class IxVideo extends LitElement {
 
   override firstUpdated(): void {
     const player = this.videoRef?.value as HTMLVideoElement;
-    const options = this._getOptions() as DataSetup;
+    const options = {} as DataSetup;
 
     this._spreadHostAttributesToPlayer(player);
     this._bubbleUpEventListeners();

--- a/src/elements/ix-video.ts
+++ b/src/elements/ix-video.ts
@@ -353,9 +353,6 @@ export class IxVideo extends LitElement {
     const vjsPlayer = vjs(player, options as VideoJsPlayerOptions, () => {
       // Prevent VJS error logging in console
       videojs.log.level('off');
-      // Update the player poster to match the video element dimensions
-      const poster = this._getPoster();
-      poster && vjsPlayer.poster(poster);
     });
     // store a reference to the videojs player in state
     this.vjsPlayer = vjsPlayer;


### PR DESCRIPTION
This commit addresses an issue where `this.source` was being updated twice in the videojs lifecycle. First, when videojs was rendered for the first time. It was given the complete setup object, including the source. Then, in the `updated()` hook, it was updating most of those option values again. This happened in such quick succession that the initial source URL request was getting canceled out by the updated source URL set in the `updated()` hook.

In the future, the logic behind setting the vjs option values needs to be re-evaluated. As it stands, its very easy to inadvertently write to the same videojs option/video property twice.