### PR TITLE
fix: add prepare script to ensure version gets bumped

### DIFF
--- a/package.json
+++ b/package.json
@@ -70,7 +70,9 @@
     "cypress:run": "cypress run",
     "cypress:run:watch": "cypress run --browser chrome --env WATCH=true",
     "cypress:run:prod": "cypress run --browser chrome --env MODE=prod",
-    "semantic-release": "semantic-release"
+    "semantic-release": "semantic-release",
+    "prepare": "npm run build",
+    "prepublishOnly": "npm run build"
   },
   "keywords": [
     "imgix",


### PR DESCRIPTION
This commit adds an npm `prepare` script to ensure the version number for ix-video patches the current semantic release version. Before this commit, the replace plugin changes were not being committed to the codebase.