### PR TITLE
chore(readme): update script CDN src in docs

### DIFF
--- a/README.md
+++ b/README.md
@@ -36,7 +36,7 @@ Or add it from a CDN:
 ```html
 <script
   type="module"
-  src="https://unpkg.com/@imgix/ix-video@latest/dist/index.bundled.js"
+  src="https://static.imgix.net/ix-video/@latest-v1/umd/ix-video.min.js"
 ></script>
 ```
 
@@ -59,7 +59,7 @@ Below is an example of how to import and use the `ix-video` custom element from 
       import {IxVideo} from './node_modules/@imgix/ix-video/dist/index.bundled.js';
     </script>
     <!-- Alternatively, the component can be loaded via a CDN -->
-    <script type="module" src="https://unpkg.com/@imgix/ix-video@latest/dist/index.bundled.js"></script>
+    <script type="module" src="https://static.imgix.net/ix-video/@latest-v1/umd/ix-video.min.js"></script>
   </head>
   <body>
     <h1>There is no bundler or bundling involved!</h1>

--- a/docs/src/overview/installation.md
+++ b/docs/src/overview/installation.md
@@ -43,7 +43,7 @@ We highly recommend self-hosting the library if you are using it in a production
   <head>
     <title>ix-video in a static HTML file</title>
     <!-- Note: type 'module' here is important -->
-    <script type="module" src="https://unpkg.com/@imgix/ix-video@latest/dist/index.bundled.js"></script>
+    <script type="module" src="https://static.imgix.net/ix-video/@latest-v1/umd/ix-video.min.js"></script>
   </head>
   <body>
     <h1>There is no bundler or bundling involved!</h1>

--- a/docs/src/overview/static.md
+++ b/docs/src/overview/static.md
@@ -11,7 +11,7 @@ Below is an example of how to import and use the `ix-video` custom element from 
       import {IxVideo} from './node_modules/@imgix/ix-video/dist/index.bundled.js';
     </script>
     <!-- Alternatively, the component can be loaded via a CDN -->
-    <script type="module" src="https://unpkg.com/@imgix/ix-video@latest/dist/index.bundled.js"></script>
+    <script type="module" src="https://static.imgix.net/ix-video/@latest-v1/umd/ix-video.min.js"></script>
   </head>
   <body>
     <h1>There is no bundler or bundling involved!</h1>


### PR DESCRIPTION
This PR removes the references to the unpkg CDN and instead adds an imgix CDN link for the script.

In order for these changes to appear on the docs site, the `docs:deploy` script needs to be run after merging.