### PR TITLE
ci: build test

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -3,6 +3,16 @@ orbs:
   cypress: cypress-io/cypress@1
   node: circleci/node@5.0.0
 jobs:
+  build-test:
+    docker:
+      - image: cimg/node:current
+    steps:
+      - checkout
+      - node/install-packages:
+          pkg-manager: npm
+      - run:
+          name: "Test whether build is successful"
+          command: npm run build
   release:
     docker:
       - image: cimg/node:current
@@ -17,7 +27,10 @@ workflows:
     jobs:
       - cypress/run:
           start: npm run dev:prod
+      - build-test:
+          start: npm run build
       - release:
           name: semantic-release 🚀
           requires:
             - cypress/run
+            - build-test

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -27,8 +27,7 @@ workflows:
     jobs:
       - cypress/run:
           start: npm run dev:prod
-      - build-test:
-          start: npm run build
+      - build-test
       - release:
           name: semantic-release 🚀
           requires:


### PR DESCRIPTION
Adds an additional test step to our CircleCI process to test successful builds.

# Before

Problems with builds can only be detected by CircleCI during the `deploy` step; this step only runs on `main` and prerelease branches. As a result, commits that break builds (included automated dependency updates by Renovate) in many cases might not be detected until after merge.
# After

We now test for a successful `build` step on every branch.
