### PR TITLE
chore: skip flaky poster tests

### DIFF
--- a/cypress/integration/ix-video/poster.spec.ts
+++ b/cypress/integration/ix-video/poster.spec.ts
@@ -15,7 +15,7 @@ context('ix-video: poster', () => {
         expect(poster).to.equal('https://sdk-test.imgix.net/amsterdam.jpg');
       });
     });
-    it('should append width/height params to poster URL equal to video size', () => {
+    it.skip('should append width/height params to poster URL equal to video size', () => {
       cy.get(ixVideoTag).then(($ixVideo) => {
         const videoTag = $ixVideo.find('[part=video]');
         const videoTagWith = parseFloat(
@@ -31,7 +31,7 @@ context('ix-video: poster', () => {
         );
       });
     });
-    it('should not accept relative URLs', () => {
+    it.skip('should not accept relative URLs', () => {
       cy.get(ixVideoTag).then(($ixVideo) => {
         const videoTag = $ixVideo.find('[part=video]');
         const videoTagWith = parseFloat(


### PR DESCRIPTION
<!--
Hello, and thanks for contributing 🎉🙌
Please take a second to fill out PRs with the following template!
-->

## Description
These poster tests rely on cypress measuring poster width CSS in the right way at the right time and break often. They need to be reworked to fail less often in the future.<!-- What is accomplished by this PR? If there is something potentially
controversial in your PR, please take a moment to tell us about your choices.-->

<!-- Before this PR... -->

<!-- After this PR... -->

<!-- Steps to test: either provide a code snippet that exhibits this change or a link to a codepen/codesandbox demo -->

## Checklist

<!-- Please ensure you've completed this checklist before submitting a PR. If
You're not submitting a bugfix or feature, delete that part of the checklist.
-->

<!-- For all Pull Requests -->
- [x] Each commit follows the [Conventional Commit](https://www.conventionalcommits.org/en/v1.0.0/#summary) spec format.
- [x] All existing unit tests are still passing (if applicable).
